### PR TITLE
De-hardcode some of the colours

### DIFF
--- a/qdigitalmeter/qdigitalmeter.py
+++ b/qdigitalmeter/qdigitalmeter.py
@@ -58,9 +58,6 @@ class QDigitalMeter(QWidget):
         self.steps = steps
         self.unit = unit
 
-        self.backgroundColor = QColor(32, 32, 32)
-        self.borderColor = QColor(80, 80, 80)
-        self.scaleColor = QColor(90, 90, 90)
         self.clippingColor = QColor(220, 50, 50)
         self.metersSpacing = 3
         self.minMeterWidth = 10
@@ -207,7 +204,7 @@ class QDigitalMeter(QWidget):
             return
 
         with QPainter(self._innerScalePixmap) as painter:
-            painter.setPen(self.scaleColor)
+            painter.setPen(self.palette().light().color())
             painter.setFont(self.font())
 
             for i, mark in enumerate(self._outerScale):
@@ -223,8 +220,8 @@ class QDigitalMeter(QWidget):
     def paintEvent(self, event: QPaintEvent):
         painter = QPainter()
         painter.begin(self)
-        painter.setPen(self.borderColor)
-        painter.setBrush(self.backgroundColor)
+        painter.setPen(self.palette().light().color())
+        painter.setBrush(self.palette().window().color())
 
         # Calculate the meter size (per single channel)
         meterRect = QRectF(0, 0, self.metersWidth(), self.metersHeight())
@@ -240,7 +237,7 @@ class QDigitalMeter(QWidget):
             if self.clipping.get(n, False):
                 painter.setPen(self.clippingColor)
             else:
-                painter.setPen(self.borderColor)
+                painter.setPen(self.palette().light().color())
 
             # Draw background and borders
             painter.drawRect(meterRect)

--- a/qdigitalmeter/qdigitalmeter.py
+++ b/qdigitalmeter/qdigitalmeter.py
@@ -23,6 +23,7 @@ from PyQt5.QtGui import (
     QLinearGradient,
     QColor,
     QPainter,
+    QPen,
     QPixmap,
     QFontDatabase,
     QFontMetrics, QResizeEvent, QPaintEvent,
@@ -61,6 +62,7 @@ class QDigitalMeter(QWidget):
         self.clippingColor = QColor(220, 50, 50)
         self.metersSpacing = 3
         self.minMeterWidth = 10
+        self.borderWidth = QPen().width()
 
         font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         font.setPointSize(font.pointSize() - 3)
@@ -87,19 +89,17 @@ class QDigitalMeter(QWidget):
         self.update()
 
     def metersHeight(self):
-        # Subtract 1 to address border width
-        return self.height() - 1
+        return self.height() - self.borderWidth
 
     def metersCount(self):
         return len(self.peaks)
 
     def metersWidth(self, forceScale: bool = False):
         metersCount = self.metersCount()
-        totalSpacing = self.metersSpacing * (metersCount - 1)
-        bordersOverflow = self.metersCount()
+        totalSpacing = self.metersSpacing * (metersCount - 1) + self.borderWidth
         outerScaleWidth = self._outerScaleWidth * int(self._canDisplayOuterScale or forceScale)
 
-        return int((self.width() - totalSpacing - bordersOverflow - outerScaleWidth) / metersCount)
+        return int((self.width() - totalSpacing - outerScaleWidth) / metersCount)
 
     def outerScaleWidth(self):
         return (

--- a/qdigitalmeter/qdigitalmeter.py
+++ b/qdigitalmeter/qdigitalmeter.py
@@ -59,9 +59,11 @@ class QDigitalMeter(QWidget):
         self.steps = steps
         self.unit = unit
 
-        self.backgroundColor = None
-        self.borderColor = None
+        palette = self.palette()
+        self.backgroundColor = palette.window().color()
+        self.borderColor = palette.light().color()
         self.clippingColor = QColor(220, 50, 50)
+        self.textColor = palette.windowText().color()
         self.metersSpacing = 3
         self.minMeterWidth = 10
         self.borderWidth = QPen().width()
@@ -206,9 +208,7 @@ class QDigitalMeter(QWidget):
             return
 
         with QPainter(self._innerScalePixmap) as painter:
-            if self.borderColor:
-                # See comment about colors in paintEvent()
-                painter.setPen(self.borderColor)
+            painter.setPen(self.borderColor)
             painter.setFont(self.font())
 
             for i, mark in enumerate(self._outerScale):
@@ -222,16 +222,6 @@ class QDigitalMeter(QWidget):
         self.updateMeterPixmap()
 
     def paintEvent(self, event: QPaintEvent):
-        if not self.backgroundColor:
-            # Ideally, we want to use the same colors as any stylesheet in use. Conveniently,
-            # Qt5 populates a widgets' palette with colors derived from the active stylesheet.
-            # Inconveniently, it appears to only do this as part of the paint sequence. Thus,
-            # it is seemingly not possible to access these colors until now.
-            palette = self.palette()
-            self.backgroundColor = palette.window().color()
-            self.borderColor = palette.light().color()
-            self.updateInnerScalePixmap()
-
         painter = QPainter()
         painter.begin(self)
         painter.setPen(self.borderColor)
@@ -296,7 +286,7 @@ class QDigitalMeter(QWidget):
         textHeight = QFontMetrics(self.font()).height()
         textOffset = textHeight / 2
 
-        painter.setPen(self.palette().windowText().color())
+        painter.setPen(self.textColor)
 
         painter.drawText(QPointF(x, 0), str(self.scale.max))
         for mark in self._outerScale:

--- a/qdigitalmeter/qdigitalmeter.py
+++ b/qdigitalmeter/qdigitalmeter.py
@@ -62,11 +62,11 @@ class QDigitalMeter(QWidget):
         self.steps = steps
         self.unit = unit
 
-        palette = self.palette()
-        self.backgroundBrush = QBrush(palette.window().color())
-        self.borderPen = QPen(palette.light().color())
-        self.clippingPen = QPen(QColor(220, 50, 50))
-        self.textPen = QPen(palette.windowText().color())
+        self.backgroundBrush = None
+        self.borderPen = None
+        self.clippingPen = None
+        self.textPen = None
+        self._updateColors()
 
         self.metersSpacing = 3
         self.minMeterWidth = 10
@@ -87,6 +87,18 @@ class QDigitalMeter(QWidget):
         self._outerScaleWidth = self.outerScaleWidth()
         self._canDisplayOuterScale = True
         self._innerScalePixmap = QPixmap()
+
+    def _updateColors(self):
+        palette = self.palette()
+        self.backgroundBrush = QBrush(palette.window().color())
+        self.borderPen = QPen(palette.light().color())
+        self.clippingPen = QPen(QColor(220, 50, 50))
+        self.textPen = QPen(palette.windowText().color())
+
+    def setStyleSheet(self, stylesheet: str):
+        super().setStyleSheet(stylesheet)
+        self.style().polish(self)
+        self._updateColors()
 
     def reset(self):
         self.peaks = [self.scale.min] * len(self.peaks)


### PR DESCRIPTION
This PR modifies the meter so it derives the colours for borders, background, and text from the application palette instead of having them hardcoded. This means that the meter can more easily integrate visually into applications using other colour schemes.

(The colours used for clipping and the meter pixmap are untouched.)

Before:
![style-before](https://github.com/FrancescoCeruti/QDigitalMeter/assets/2053873/1a1387d6-a288-444b-92f2-70928cf459d6)

After:
![style-after](https://github.com/FrancescoCeruti/QDigitalMeter/assets/2053873/fc7b3914-c108-46ae-95a0-a70ec6befe0c)

This PR also arguably improves the `{meter}.setStyleSheet(...)` method (as demonstrated in the example in the ReadMe), as it now actually uses the provided `background` rgb colour as the background colour of the meter.