### PR TITLE
Simplify setting min/max when subclassing LinearScale

### DIFF
--- a/qdigitalmeter/scales.py
+++ b/qdigitalmeter/scales.py
@@ -16,6 +16,7 @@
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
 from abc import abstractmethod, ABC
+from dataclasses import dataclass
 
 
 class Scale(ABC):
@@ -56,6 +57,7 @@ class IECScale(Scale):
         return scale / 100
 
 
+@dataclass
 class LinearScale(Scale):
     min: int = -60
     max: int = 0

--- a/qdigitalmeter/scales.py
+++ b/qdigitalmeter/scales.py
@@ -57,9 +57,8 @@ class IECScale(Scale):
 
 
 class LinearScale(Scale):
-    def __init__(self, min_value: int = -60, max_value: int = 0):
-        self.min = min_value
-        self.max = max_value
+    min: int = -60
+    max: int = 0
 
     def scale(self, value):
         if value < self.min:


### PR DESCRIPTION
Allows easier creation of a sub-class of `LinearScale` with different `min` or `max` instead of having to override the `__init__()` method and/or pass the preferred `min`/`max` values to each instance.

In other words, this:
```python
class ExampleScale(LinearScale):
    min = -20
```

Instead of this:
```python
class ExampleScale(LinearScale):
    def __init__(self, min_value: int = -20, max_value: int = 0):
        super().__init__(min_value, max_value)
```